### PR TITLE
Fixing some of the configuration documentation

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -52,12 +52,13 @@ var format = require('util').format;
  *        when connecting via ldaps://. See
  *        http://nodejs.org/api/tls.html#tls_tls_connect_options_callback
  *        for available options
- *    maxConnections {Integeer}
+ *    maxConnections {Integer}
  *        Whether or not to enable connection pooling, and if so, how many to
  *        maintain.
- *    bindDN {String}
+ *    bindDn {String}
  *        Defaults to adminDn
- *    bindCredentials {String}
+ *    Credentials {String}
+ *        Used as the client bindCredentials
  *        Defaults to adminPassword
  *    checkInterval {Integer}
  *        How often to schedule health checks for the connection pool.


### PR DESCRIPTION
Some of the configuration documentation has small errors where the doc refers to one name, but the code another. Updating the doc to match the code.
I set the wrong options at first, so thought it may be worth updating :-)
(Also some spelling tweaks :-) )
