### PR TITLE
Bump bcrypt to 0.7.8 t solve build issues on Win64

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "lru-cache": "2.5.0"
   },
   "optionalDependencies": {
-    "bcrypt": "0.7.7"
+    "bcrypt": "0.7.8"
   }
 }


### PR DESCRIPTION
bcrypt 0.7.7 fails to build on Win64 via node-gyp claiming unable to find "openssl/rand.h" though all dependencies are available whereas 0.7.8 builds fine.
