### PR TITLE
Enable binding against non-standard user property

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MIT. See "LICENSE" file.
 
 ## `LdapAuth` Config Options
 
-[Use the source Luke](https://github.com/vesse/node-ldapauth-fork/blob/master/lib/ldapauth.js#L25-76)
+[Use the source Luke](https://github.com/vesse/node-ldapauth-fork/blob/master/lib/ldapauth.js#L25-79)
 
 
 ## express/connect basicAuth example

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -30,6 +30,9 @@ var bcrypt;
  *        Optional, e.g. 'uid=myapp,ou=users,o=example.com'. Alias: adminDn
  *    bindCredentials {String}
  *        Password for bindDn. Aliases: Credentials, adminPassword
+ *    bindProperty {String}
+ *        Optional, default 'dn'. Property of user to bind against client
+ *        e.g. 'name', 'email'
  *    searchBase {String}
  *        The base DN from which to search for users by username.
  *         E.g. 'ou=users,o=example.com'
@@ -83,7 +86,8 @@ function LdapAuth(opts) {
 
   this.log = opts.log4js && opts.log4js.getLogger('ldapauth');
 
-  this.opts.searchScope || (this.opts.searchScope = 'sub')
+  this.opts.searchScope || (this.opts.searchScope = 'sub');
+  this.opts.bindProperty || (this.opts.bindProperty = 'dn');
 
   if (opts.cache) {
     var Cache = require('./cache');
@@ -245,8 +249,9 @@ LdapAuth.prototype.authenticate = function (username, password, callback) {
       return callback(err);
     if (!user)
       return callback(format('no such user: "%s"', username));
+
     // 2. Attempt to bind as that user to check password.
-    self._userClient.bind(user.dn, password, function (err) {
+    self._userClient.bind(user[self.opts.bindProperty], password, function (err) {
       if (err) {
         self.log && self.log.trace('ldap authenticate: bind error: %s', err);
         return callback(err);


### PR DESCRIPTION
In instances where the LDAP services binds against another user property, e.g. user.name or user.email, allow the client to determine  which property to bind against.

{
  ... options
  bindProperty: 'name'
  ...
}