### PR TITLE
Add user object to error callbacks

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -305,13 +305,13 @@ LdapAuth.prototype.authenticate = function (username, password, callback) {
     self._userClient.bind(user[self.opts.bindProperty], password, function (err) {
       if (err) {
         self.log && self.log.trace('ldap authenticate: bind error: %s', err);
-        return callback(err);
+        return callback(err, user);
       }
       // 3. If requested, fetch user groups
       self._getGroups(user, function(err, user) {
         if (err) {
           self.log && self.log.trace('ldap authenticate: group search error %s', err);
-          return callback(err);
+          return callback(err, user);
         }
         if (self.opts.cache) {
           bcrypt.hash(password, self._salt, function (err, hash) {


### PR DESCRIPTION
If you bind to a non compliant LDAP directory, a bind attempt to a
locked account return an error 49 (InvalidCredentials) instead of a
constraint violation error.  By returning the user object even on error,
this allows the caller to inspect user's attribute to further debug the
bind error.  This will be usefull in our implementation of passport-ldapauth