### PR TITLE
Updated ldapjs Dependency to Fix TypeError When Using LDAPS in Certain Environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "bcryptjs": "2.1.0",
-    "ldapjs": "0.7.1",
+    "ldapjs": "git://github.com/mcavage/node-ldapjs.git#19f2c167839fc9cfb46fdb8ee1ef5275100fd578",
     "lru-cache": "2.5.0"
   }
 }


### PR DESCRIPTION
This PR fixes a TypeError when using the LDAPS protocol in certain environments (tested on Windows 7 x64, OpenSSL 1.0.2a and 1.0.1e):

```
TypeError: Cannot read property 'on' of undefined
    at setupSocket (c:\app\node_modules\passport-ldapauth\node_modules\ldapauth-fork\node_modules\ldapjs\lib\client\client.js:111:14)
    at Client._connect (c:\app\node_modules\passport-ldapauth\node_modules\ldapauth-fork\node_modules\ldapjs\lib\client\client.js:742:3)
    at new Client (c:\app\node_modules\passport-ldapauth\node_modules\ldapauth-fork\node_modules\ldapjs\lib\client\client.js:247:22)
    at Object.createClient (c:\app\node_modules\passport-ldapauth\node_modules\ldapauth-fork\node_modules\ldapjs\lib\client\index.js:60:12)
    at new LdapAuth (c:\app\node_modules\passport-ldapauth\node_modules\ldapauth-fork\lib\ldapauth.js:129:28)
    at handleAuthentication (c:\app\node_modules\passport-ldapauth\lib\passport-ldapauth\strategy.js:140:10)
    at callback (c:\app\node_modules\passport-ldapauth\lib\passport-ldapauth\strategy.js:181:26)
    at null.getOptions (c:\app\auth.js:31:17)
    at Strategy.authenticate (c:\app\node_modules\passport-ldapauth\lib\passport-ldapauth\strategy.js:187:10)
    at attempt (c:\app\node_modules\passport\lib\middleware\authenticate.js:341:16)
```

See [this StackOverflow question](http://stackoverflow.com/questions/28773546/nodejs-passport-ldapauth-cannot-read-on-property-of-undefined) where another user encountered the same error.

If you decide to pull this, I kindly request that you release a new version of node-ldapauth-fork and passport-ldapauth.