### PR TITLE
Unhandled 'error' event

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -129,6 +129,10 @@ function LdapAuth(opts) {
   this._adminClient = ldap.createClient(this.clientOpts);
   this._adminBound = false;
   this._userClient = ldap.createClient(this.clientOpts);
+  //what's the best place to handle this error to return proper error messages to external users?
+  this._userClient.on('error', function(e) {
+    debug("An error occured during LDAP client connection", e);
+  });
 
   if (opts.cache) {
     this._salt = bcrypt.genSaltSync();
@@ -168,6 +172,11 @@ LdapAuth.prototype._adminBind = function (callback) {
     return callback();
   }
   var self = this;
+  //handle DNS errors
+  this._adminClient.once('error', function(err) {
+    debug("An error occured during LDAP client connection", err);
+    callback(err);
+  });
   this._adminClient.bind(this.clientOpts.bindDn, this.clientOpts.bindCredentials,
                          function (err) {
     if (err) {


### PR DESCRIPTION
As per the discussion in https://github.com/vesse/passport-ldapauth/issues/29, I'm investigating an Unhandled error event crash in my application related to DNS errors with the LDAP server's address.

I found 2 error handlers are missing, one on _userClient and one on _adminClient. I have a "working" version that I tried to format into a pull request. The handlers are both required to resolve the issue, but I couldn't find a proper place to handle the _userClient error.

The obvious choice would have been - code snippet below - in LdapAuth.prototype.authenticate, attaching a one time handler before the userclient binds, but that didn't work. The nature of these errors and the connection order is something I still don't understand.

``` js
self._userClient.once('error', function(err) {
  callback(err);
});
self._userClient.bind(user[self.opts.bindProperty], password, function (err) {
```

Does this help with coming up with a nice solution for users of passport-ldapauth?
