### PR TITLE
Fix unhandled 'error' event in Ldapjs clients.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # node-ldapauth-fork Changelog
 
+## 2.3.4
+
+- [issue #25] Fix unhandled 'error' event
+
 ## 2.3.3
 
 - [issue #20] Sanitize user input

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -128,7 +128,6 @@ function LdapAuth(opts) {
 
   this._adminClient = ldap.createClient(this.clientOpts);
   this._adminBound = false;
-  this._userClient = ldap.createClient(this.clientOpts);
 
   if (opts.cache) {
     this._salt = bcrypt.genSaltSync();
@@ -151,7 +150,9 @@ LdapAuth.prototype.close = function (callback) {
   // It seems to be OK just to call unbind regardless of if the
   // client has been bound (e.g. how ldapjs pool destroy does)
   self._adminClient.unbind(function(err) {
-    self._userClient.unbind(callback);
+    if (self._userClient) {
+      self._userClient.unbind(callback);
+  }
   });
 };
 
@@ -168,6 +169,10 @@ LdapAuth.prototype._adminBind = function (callback) {
     return callback();
   }
   var self = this;
+  this._adminClient.on('error', function (err) {
+    self.log && self.log.trace('ldap authenticate: bind error: %s', err);
+    return callback(err);
+  });
   this._adminClient.bind(this.clientOpts.bindDn, this.clientOpts.bindCredentials,
                          function (err) {
     if (err) {
@@ -313,6 +318,13 @@ LdapAuth.prototype.authenticate = function (username, password, callback) {
       return callback(format('no such user: "%s"', username));
 
     // 2. Attempt to bind as that user to check password.
+    if (!self._userClient) {
+      self._userClient = ldap.createClient(self.clientOpts)
+      self._userClient.on('error', function (err){
+        self.log && self.log.trace('ldap authenticate: bind error: %s', err);
+        return callback(err);
+      });
+    }
     self._userClient.bind(user[self.opts.bindProperty], password, function (err) {
       if (err) {
         self.log && self.log.trace('ldap authenticate: bind error: %s', err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldapauth-fork",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "./lib/ldapauth.js",
   "description": "Authenticate against an LDAP server",
   "author": "Vesa Poikajärvi <vesa.poikajarvi@iki.fi>",


### PR DESCRIPTION
When the LDAP server connection goes down, an 'error' event is emitted by ldapjs which is not getting handled. Added the error handling code and updated the version. [Issue #25]