### PR TITLE
changes ldapjs dependency to use v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "bcryptjs": "2.1.0",
-    "ldapjs": "0.7.1",
+    "ldapjs": "1.0.0",
     "lru-cache": "2.5.0"
   }
 }


### PR DESCRIPTION
ldapjs 1.0.0 has removed the dtrace dependency that causes issues when npm installing on mac