### PR TITLE
Versatile group filter

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -149,6 +149,13 @@ function LdapAuth(opts) {
   }
 
   if (opts.groupSearchBase && opts.groupSearchFilter) {
+    if (typeof opts.groupSearchFilter === 'string') {
+      var groupSearchFilter = opts.groupSearchFilter;
+      opts.groupSearchFilter = function(user) {
+        return groupSearchFilter.replace(/{{dn}}/g, user[opts.groupDnProperty]);
+      };
+    }
+
     this._getGroups = this._findGroups;
   } else {
     // Assign an async identity function so there is no need to branch
@@ -289,14 +296,7 @@ LdapAuth.prototype._findGroups = function(user, callback) {
     return callback("no user");
   }
 
-  var searchFilter = '';
-
-  if ((typeof (self.opts.groupSearchFilter) === 'string')) {
-	searchFilter = self.opts.groupSearchFilter.replace(/{{dn}}/g, user[self.opts.groupDnProperty]);
-  } else {
-        searchFilter = self.opts.groupSearchFilter(user);
-  }
-
+  var searchFilter = self.opts.groupSearchFilter(user);
 
   var opts = {filter: searchFilter, scope: self.opts.groupSearchScope};
   if (self.opts.groupSearchAttributes) {

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -63,10 +63,11 @@ var getOption = function(obj, keys) {
  *        also groupSearchFilter must be defined for the search to work.
  *    groupSearchScope {String}
  *        Optional, default 'sub'.
- *    groupSearchFilter {String}
+ *    groupSearchFilter {String | function(User): String }
  *        Optional. LDAP search filter for groups. The following literals are
  *        interpolated from the found user object: '{{dn}}' the property
- *        configured with groupDnProperty.
+ *        configured with groupDnProperty. Optionally you can also assign a function instead,
+ *	  which passes a user object, from this a dynamic groupsearchfilter can be retrieved.
  *    groupSearchAttributes {Array}
  *        Optional, default all. Array of attributes to fetch from LDAP server.
  *    log4js {Module}
@@ -288,7 +289,15 @@ LdapAuth.prototype._findGroups = function(user, callback) {
     return callback("no user");
   }
 
-  var searchFilter = self.opts.groupSearchFilter.replace(/{{dn}}/g, user[self.opts.groupDnProperty]);
+  var searchFilter = "";
+
+  if( typeof self.opts.groupSearchFilter === "string" ) {
+	searchFilter = self.opts.groupSearchFilter.replace(/{{dn}}/g, user[self.opts.groupDnProperty]);
+  } else {
+        searchFilter = self.opts.groupSearchFilter(user);
+  }
+
+
   var opts = {filter: searchFilter, scope: self.opts.groupSearchScope};
   if (self.opts.groupSearchAttributes) {
     opts.attributes = self.opts.groupSearchAttributes;

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -289,9 +289,9 @@ LdapAuth.prototype._findGroups = function(user, callback) {
     return callback("no user");
   }
 
-  var searchFilter = "";
+  var searchFilter = '';
 
-  if( typeof self.opts.groupSearchFilter === "string" ) {
+  if ((typeof (self.opts.groupSearchFilter) === 'string')) {
 	searchFilter = self.opts.groupSearchFilter.replace(/{{dn}}/g, user[self.opts.groupDnProperty]);
   } else {
         searchFilter = self.opts.groupSearchFilter(user);


### PR DESCRIPTION
As mentioned in an issue some days ago, I have patched the groupfilter to allow for passing of a callback function next to the previously defined string. The first and only argument passed is the user object, which can be used to form a search filter string which needs to be returned.

I have tried out both the "old" functionality with a fixed string and tested it out with a dynamic filter:

```
groupSearchFilter: (user) => {
    return "(|(&(cn=*)(memberUid="+user.uid+"))(&(cn=*)(gidNumber="+user.gidNumber+")))";
}
```