### PR TITLE
Make LdapAuth an EventEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ var options = {
     ...
 };
 var auth = new LdapAuth(options);
+auth.on('error', function (err) {
+    console.error('LdapAuth: ', err);
+});
 ...
 auth.authenticate(username, password, function(err, user) { ... });
 ...

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -17,6 +17,8 @@ var ldap = require('ldapjs');
 var debug = console.warn;
 var format = require('util').format;
 var bcrypt = require('bcryptjs');
+var inherits = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
 
 // Get option that may be defined under different names, but accept
 // the first one that is actually defined in the given object
@@ -118,6 +120,8 @@ function LdapAuth(opts) {
   this.opts.groupSearchScope || (this.opts.groupSearchScope = 'sub');
   this.opts.groupDnProperty || (this.opts.groupDnProperty = 'dn');
 
+  EventEmitter.call(this);
+
   if (opts.cache) {
     var Cache = require('./cache');
     this.userCache = new Cache(100, 300, this.log, 'user');
@@ -144,6 +148,13 @@ function LdapAuth(opts) {
   this._adminBound = false;
   this._userClient = ldap.createClient(this.clientOpts);
 
+  var self = this;
+  function emitErr(err) {
+    self.emit('error', err);
+  }
+  this._adminClient.on('error', emitErr);
+  this._userClient.on('error', emitErr);
+
   if (opts.cache) {
     this._salt = bcrypt.genSaltSync();
   }
@@ -165,7 +176,7 @@ function LdapAuth(opts) {
     }
   }
 };
-
+inherits(LdapAuth, EventEmitter);
 
 LdapAuth.prototype.close = function (callback) {
   var self = this;


### PR DESCRIPTION
An 'error' event emitted from ldapjs will be thrown because there is
no listener. Make LdapAuth an EventEmitter so these events can be
handled properly.

This approach is similar to

https://github.com/vesse/node-ldapauth-fork/pull/20#issuecomment-113585682

If reconnect is set, ldapjs will automatically retry so the error
handler can simply output some logs.

Related issues: #25 , #39
