### PR TITLE
fixed failure to handle connectTimeout event

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -106,6 +106,8 @@ function LdapAuth(opts) {
 
   this._adminClient.on('error', this._handleError.bind(this));
   this._userClient.on('error', this._handleError.bind(this));
+  this._adminClient.on('connectTimeout', this._handleError.bind(this));
+  this._userClient.on('connectTimeout', this._handleError.bind(this));
 
   if (opts.groupSearchBase && opts.groupSearchFilter) {
     if (typeof opts.groupSearchFilter === 'string') {


### PR DESCRIPTION
I found that ldap clients were emitting {{connectTimeout}} events (I was being throttled I suppose) but the ldapauth-fork was not handling them.  see: https://github.com/mcavage/node-ldapjs/blob/7059cf6b8a0b4ff4c566714d97f3cef04f887c3b/lib/client/client.js#L1226