### PR TITLE
Updated ldapjs to 1.0.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/ldapjs": "^1.0.0",
     "@types/node": "^9.6.2",
     "bcryptjs": "^2.4.0",
-    "ldapjs": "^1.0.1",
+    "ldapjs": "^1.0.2",
     "lru-cache": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated ldapjs to 1.0.2.
There was an error in the dtrace-provider of ldapjs 1.0.1, and it has been fixed in version 1.0.2.
links: https://github.com/joyent/node-ldapjs/issues/451