### PR TITLE
Add connect callback for adminClient to rebind on reconnect

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -106,6 +106,12 @@ function LdapAuth(opts) {
 
   this._adminClient.on('error', this._handleError.bind(this));
   this._userClient.on('error', this._handleError.bind(this));
+
+  var self = this;
+  this._adminClient.on('connect', function() {
+    self._onConnectAdmin();
+  });
+
   this._adminClient.on('connectTimeout', this._handleError.bind(this));
   this._userClient.on('connectTimeout', this._handleError.bind(this));
 
@@ -159,6 +165,38 @@ LdapAuth.prototype._handleError = function(err) {
 };
 
 /**
+ * Bind adminClient to the admin user on connect
+ *
+ * @private
+ * @param {voidCallback} callback - Callback that checks possible error, optional
+ * @returns {undefined}
+ */
+LdapAuth.prototype._onConnectAdmin = function(callback) {
+  var self = this;
+
+  // Anonymous binding
+  if (typeof self.bindDN === 'undefined' || self.bindDN === null) {
+    return callback ? callback() : null;
+  }
+
+  self.log && self.log.trace('ldap authenticate: bind: %s', self.bindDN);
+  self._adminClient.bind(
+    self.bindDN,
+    self.bindCredentials,
+    function(err) {
+      if (err) {
+        self.log && self.log.trace('ldap authenticate: bind error: %s', err);
+        self._adminBound = false;
+        return callback ? callback(err) : null;
+      }
+
+      self.log && self.log.trace('ldap authenticate: bind ok');
+      self._adminBound = true;
+      return callback ? callback() : null;
+    });
+}
+
+/**
  * Ensure that `this._adminClient` is bound.
  *
  * @private
@@ -166,26 +204,12 @@ LdapAuth.prototype._handleError = function(err) {
  * @returns {undefined}
  */
 LdapAuth.prototype._adminBind = function(callback) {
-  // Anonymous binding
-  if (typeof this.bindDN === 'undefined' || this.bindDN === null) {
-    return callback();
-  }
   if (this._adminBound) {
     return callback();
   }
-  var self = this;
-  this._adminClient.bind(
-    this.bindDN,
-    this.bindCredentials,
-    function(err) {
-      if (err) {
-        self.log && self.log.trace('ldap authenticate: bind error: %s', err);
-        return callback(err);
-      }
-      self._adminBound = true;
-      return callback();
-    }
-  );
+
+  // Call the connect handler with a callback
+  return this._onConnectAdmin(callback);
 };
 
 /**

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -176,6 +176,7 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
 
   // Anonymous binding
   if (typeof self.bindDN === 'undefined' || self.bindDN === null) {
+    self._adminBound = true;
     return callback ? callback() : null;
   }
 


### PR DESCRIPTION
This solves the anonymous after reconnect issue from #67, and adds a bit of logging around binding `adminClient`.  Let me know if you'd like anything further changed.