### PR TITLE
Add starttls option

### DIFF
--- a/lib/ldapauth.d.ts
+++ b/lib/ldapauth.d.ts
@@ -102,6 +102,11 @@ declare namespace LdapAuth {
          * 5 minutes.
          */
         cache?: boolean;
+
+        /**
+         * If true, then intialize TLS using the starttls mechanism.
+         */
+        starttls?: boolean;
     }
 }
 

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -107,8 +107,22 @@ function LdapAuth(opts) {
   this._adminClient.on('error', this._handleError.bind(this));
   this._userClient.on('error', this._handleError.bind(this));
 
-  if (opts.reconnect) {
-    var self = this;
+  var self = this;
+  if (this.opts.starttls) {
+    // When starttls is enabled, this callback supplants the 'connect' callback
+    this._adminClient.starttls(this.opts.tlsOptions, this._adminClient.controls, function(err) {
+      if (err) {
+        self._handleError(err);
+      } else {
+        self._onConnectAdmin();
+      }
+    });
+    this._userClient.starttls(this.opts.tlsOptions, this._userClient.controls, function(err) {
+      if (err) {
+        self._handleError(err);
+      }
+    });
+  } else if (opts.reconnect) {
     this.once('_installReconnectListener', function() {
       self.log && self.log.trace('install reconnect listener');
       self._adminClient.on('connect', function() {


### PR DESCRIPTION
This adds a boolean `starttls` option which, if set, will execute [starttls](http://ldapjs.org/client.html#starttls) before binding, emitting an `error` should the TLS setup process fail. 

Closes #59 