### PR TITLE
Defer the installation of reconnect listener

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -200,7 +200,7 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
 
       self.log && self.log.trace('ldap authenticate: bind ok');
       self._adminBound = true;
-      if (opts.reconnect) {
+      if (self.opts.reconnect) {
         self.emit('_installReconnectListener');
       }
       return callback ? callback() : null;

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -112,6 +112,7 @@ function LdapAuth(opts) {
     this.once('_installReconnectListener', function() {
       self.log && self.log.trace('install reconnect listener');
       self._adminClient.on('connect', function() {
+        self._adminBound = false;
         self._onConnectAdmin();
       });
     });
@@ -185,6 +186,10 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
   if (typeof self.bindDN === 'undefined' || self.bindDN === null) {
     self._adminBound = true;
     return callback ? callback() : null;
+  }
+  
+  if (this._adminBound) {		
+    return callback ? callback() : null;		
   }
 
   self.log && self.log.trace('ldap authenticate: bind: %s', self.bindDN);

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -107,13 +107,15 @@ function LdapAuth(opts) {
   this._adminClient.on('error', this._handleError.bind(this));
   this._userClient.on('error', this._handleError.bind(this));
 
-  var self = this;
-  this.once('_installReconnectListener', function() {
-    self.log && self.log.trace('install reconnect listener');
-    self._adminClient.on('connect', function() {
-      self._onConnectAdmin();
+  if (opts.reconnect) {
+    var self = this;
+    this.once('_installReconnectListener', function() {
+      self.log && self.log.trace('install reconnect listener');
+      self._adminClient.on('connect', function() {
+        self._onConnectAdmin();
+      });
     });
-  });
+  }
 
   this._adminClient.on('connectTimeout', this._handleError.bind(this));
   this._userClient.on('connectTimeout', this._handleError.bind(this));
@@ -198,7 +200,9 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
 
       self.log && self.log.trace('ldap authenticate: bind ok');
       self._adminBound = true;
-      self.emit('_installReconnectListener');
+      if (opts.reconnect) {
+        self.emit('_installReconnectListener');
+      }
       return callback ? callback() : null;
     });
 };

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -112,7 +112,6 @@ function LdapAuth(opts) {
     this.once('_installReconnectListener', function() {
       self.log && self.log.trace('install reconnect listener');
       self._adminClient.on('connect', function() {
-        self._adminBound = false;
         self._onConnectAdmin();
       });
     });
@@ -186,10 +185,6 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
   if (typeof self.bindDN === 'undefined' || self.bindDN === null) {
     self._adminBound = true;
     return callback ? callback() : null;
-  }
-  
-  if (this._adminBound) {		
-    return callback ? callback() : null;		
   }
 
   self.log && self.log.trace('ldap authenticate: bind: %s', self.bindDN);

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -108,8 +108,11 @@ function LdapAuth(opts) {
   this._userClient.on('error', this._handleError.bind(this));
 
   var self = this;
-  this._adminClient.on('connect', function() {
-    self._onConnectAdmin();
+  this.once('_installReconnectListener', function() {
+    self.log && self.log.trace('install reconnect listener');
+    self._adminClient.on('connect', function() {
+      self._onConnectAdmin();
+    });
   });
 
   this._adminClient.on('connectTimeout', this._handleError.bind(this));
@@ -195,6 +198,7 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
 
       self.log && self.log.trace('ldap authenticate: bind ok');
       self._adminBound = true;
+      self.emit('_installReconnectListener');
       return callback ? callback() : null;
     });
 };


### PR DESCRIPTION
Try to fix https://github.com/vesse/node-ldapauth-fork/issues/69 by delay the installation of reconnect listener.

With this fix. The reconnect listener will be installed **after** adminClient is bound successfully for the first time. So it will not be trigged duplicately.