### PR TITLE
No connect handler unless reconnect or adminBindOnConnect are true

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -107,10 +107,16 @@ function LdapAuth(opts) {
   this._adminClient.on('error', this._handleError.bind(this));
   this._userClient.on('error', this._handleError.bind(this));
 
-  var self = this;
-  this._adminClient.on('connect', function() {
-    self._onConnectAdmin();
-  });
+  if (opts.reconnect || opts.adminBindOnConnect) {
+    this._useConnectHandler = true;
+
+    var self = this;
+    this._adminClient.on('connect', function() {
+      self._onConnectAdmin();
+    });
+  } else {
+    this._useConnectHandler = false;
+  }
 
   this._adminClient.on('connectTimeout', this._handleError.bind(this));
   this._userClient.on('connectTimeout', this._handleError.bind(this));
@@ -207,7 +213,7 @@ LdapAuth.prototype._onConnectAdmin = function(callback) {
  * @returns {undefined}
  */
 LdapAuth.prototype._adminBind = function(callback) {
-  if (this._adminBound) {
+  if (this._adminBound || this._useConnectHandler) {
     return callback();
   }
 


### PR DESCRIPTION
This should prevent the double bind issue with "one-shot" usage, and
any bindings triggered before connecting when reconnect is used.