### PR TITLE
Allow any version of @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@types/ldapjs": "^1.0.0",
-    "@types/node": "^10.12.12",
+    "@types/node": "*",
     "bcryptjs": "^2.4.0",
     "ldapjs": "^1.0.2",
     "lru-cache": "^5.1.1"


### PR DESCRIPTION
This fixes a typescript error when a newer @types/node is installed along with passport-ldapauth.

tsc error:
```
node_modules/ldapauth-fork/lib/ldapauth.d.ts:6:23 - error TS4090: Conflicting definitions for 'node' found at '***/node_modules/ldapauth-fork/node_modules/@types/node/ts3.2/index.d.ts' and '***/node_modules/@types/node/ts3.5/index.d.ts'. Consider installing a specific version of this library to resolve the conflict.

6 /// <reference types="node"/>
                        ~~~~

node_modules/passport-ldapauth/lib/passport-ldapauth/strategy.d.ts:6:23 - error TS4090: Conflicting definitions for 'node' found at '***/node_modules/passport-ldapauth/node_modules/@types/node/ts3.2/index.d.ts' and '***/node_modules/@types/node/ts3.5/index.d.ts'. Consider installing a specific version of this library to resolve the conflict.

6 /// <reference types="node"/>
                        ~~~~

Found 2 errors.
```