### PR TITLE
feat(auth-without-admin): let get request user data itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Required ldapjs client options:
 
 ldapauth-fork options:
 
-  - `bindDN` - Admin connection DN, e.g. *uid=myapp,ou=users,dc=example,dc=org*. Optional. If not given at all, admin client is not bound. Giving empty string may result in anonymous bind when allowed.
-  - `bindCredentials` - Password for bindDN.
+  - `bindDN` - Admin connection DN, e.g. *uid=myapp,ou=users,dc=example,dc=org*. Optional. If not given at all, admin client is not bound. Giving empty string may result in anonymous bind when allowed. If you only want get request user data, you can get request username with {{username}}
+  - `bindCredentials` - Password for bindDN. If you are using only requested user data , set it with {{password}}
   - `searchBase` - The base DN from which to search for users by username. E.g. *ou=users,dc=example,dc=org*
   - `searchFilter` - LDAP search filter with which to find a user by username, e.g. *(uid={{username}})*. Use the literal *{{username}}* to have the given username interpolated in for the LDAP search.
   - `searchAttributes` - Optional, default all. Array of attributes to fetch from LDAP server.

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -397,6 +397,9 @@ LdapAuth.prototype.authenticate = function(username, password, callback) {
     }
   }
 
+  // 0. Replace bindDN and bindCredentials with request data
+  self._replaceUserPasswordDN(username, password);
+
   // 1. Find the user DN in question.
   self._findUser(username, function(findErr, user) {
     if (findErr) {
@@ -432,6 +435,21 @@ LdapAuth.prototype.authenticate = function(username, password, callback) {
       });
     });
   });
+};
+
+/**
+ * Authenticate without Admin. Only need User request data to get itself
+ *
+ * @param {string} username - The username to authenticate from request data
+ * @param {string} password - The password to verify  from request data
+ * @returns {void}
+ */
+LdapAuth.prototype._replaceUserPasswordDN = function (username, password) {
+  var self = this;
+  self.bindDN = self.opts.bindDN.replace(/{{username}}/g, sanitizeInput(username));
+  self.bindCredentials = self.opts.bindCredentials.replace(/{{password}}/g, sanitizeInput(password));
+  self.opts.bindDN = self.opts.bindDN.replace(/{{username}}/g, sanitizeInput(username));
+  self.opts.bindCredentials = self.opts.bindCredentials.replace(/{{password}}/g, sanitizeInput(password));
 };
 
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,50 +1,89 @@
 /**
  * A dummy manual test script
  */
-import * as Logger from 'bunyan';
-import * as LdapAuth from '../lib/ldapauth';
-
-const log = new Logger({
-    name: 'ldap',
-    component: 'client',
-    stream: process.stderr,
-    level: 'trace'
-});
-
-const opts: LdapAuth.Options = {
-  url: 'ldap://ldap.forumsys.com:389',
-  bindDN: 'cn=read-only-admin,dc=example,dc=com',
-  bindCredentials: 'password',
-  searchBase: 'dc=example,dc=com',
-  searchFilter: '(uid={{username}})',
-  log: log,
-  cache: true,
-  includeRaw: true,
-  groupSearchFilter: '(member={{dn}})',
-  groupSearchBase: 'dc=example,dc=com'
-};
-
-const auth = new LdapAuth(opts);
-
-auth.on('error', (err) => {
-    console.warn(err);
-    // TODO: auth.close() doesn't do anything here
-});
-
-auth.authenticate('riemann', 'password', (err, user) => {
-    if (err) {
-        console.warn(err);
-        auth.close(() => console.log('Unbound'));
-    } else {
-        console.log(user);
-        // Re-auth to be able to verify cache works
-        auth.authenticate('riemann', 'password', (err, user) => {
-            if (err) {
-                console.warn(err);
-            } else {
-                console.log('Re-auth user DN:', user.dn);
-            }
-            auth.close();
-        });
-    }
-});
+ import * as Logger from 'bunyan';
+ import * as LdapAuth from '../lib/ldapauth';
+ 
+ const log = new Logger({
+     name: 'ldap',
+     component: 'client',
+     stream: process.stderr,
+     level: 'trace'
+ });
+ 
+ const opts: LdapAuth.Options = {
+   url: 'ldap://ldap.forumsys.com:389',
+   bindDN: 'cn=read-only-admin,dc=example,dc=com',
+   bindCredentials: 'password',
+   searchBase: 'dc=example,dc=com',
+   searchFilter: '(uid={{username}})',
+   log: log,
+   cache: true,
+   includeRaw: true,
+   groupSearchFilter: '(member={{dn}})',
+   groupSearchBase: 'dc=example,dc=com'
+ };
+ 
+ const optsWithoutAdmin: LdapAuth.Options = {
+     url: 'ldap://ldap.forumsys.com:389',
+     bindDN: 'uid={{username}},dc=example,dc=com',
+     bindCredentials: '{{password}}',
+     searchBase: 'dc=example,dc=com',
+     searchFilter: '(uid={{username}})',
+     log: log,
+     cache: true,
+     includeRaw: true,
+     groupSearchFilter: '(member={{dn}})',
+     groupSearchBase: 'dc=example,dc=com'
+   };
+ 
+ const auth = new LdapAuth(opts);
+ 
+ auth.on('error', (err) => {
+     console.warn(err);
+     // TODO: auth.close() doesn't do anything here
+ });
+ 
+ auth.authenticate('riemann', 'password', (err, user) => {
+     if (err) {
+         console.warn(err);
+         auth.close(() => console.log('Unbound'));
+     } else {
+         console.log(user);
+         // Re-auth to be able to verify cache works
+         auth.authenticate('riemann', 'password', (err, user) => {
+             if (err) {
+                 console.warn(err);
+             } else {
+                 console.log('Re-auth user DN:', user.dn);
+             }
+             auth.close();
+         });
+     }
+ });
+ 
+ const authWithoutAdmin = new LdapAuth(optsWithoutAdmin);
+ 
+ authWithoutAdmin.on('error', (err) => {
+     console.warn(err);
+     // TODO: auth.close() doesn't do anything here
+ });
+ 
+ authWithoutAdmin.authenticate('riemann', 'password', (err, user) => {
+     if (err) {
+         console.warn(err);
+         authWithoutAdmin.close(() => console.log('Unbound'));
+     } else {
+         console.log(user);
+         // Re-auth to be able to verify cache works
+         authWithoutAdmin.authenticate('riemann', 'password', (err, user) => {
+             if (err) {
+                 console.warn(err);
+             } else {
+                 console.log('Re-auth user DN:', user.dn);
+             }
+             authWithoutAdmin.close();
+         });
+     }
+ });
+ 


### PR DESCRIPTION
Allows to validate a user and return the requested user information without the need to use admin credentials.

For use user data requested, use {{username}} and {{password}} into opts config:

```
bindDN: 'uid={{username}},dc=example,dc=com',   
bindCredentials: '{{password}}',     
```     

