### PR TITLE
Update README.md: Document possible usage of URL array in addition to single string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ auth.close(function(err) { ... })
 
 Required ldapjs client options:
 
-  - `url` - LDAP server URL, eg. *ldaps://ldap.example.org:636*
+  - `url` - LDAP server URL, eg. *ldaps://ldap.example.org:636*, or a list of URLs, e.g. `["ldaps://ldap.example.org:636"]`
 
 ldapauth-fork options:
 


### PR DESCRIPTION
The underlying ldapjs library supports a list of URLs: http://ldapjs.org/client.html