### PR TITLE
feat(ldapauth): sanitize input for group search filter

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -53,6 +53,25 @@ var getOption = function(obj, keys) {
 };
 
 /**
+ * Sanitize LDAP special characters from input
+ *
+ * {@link https://tools.ietf.org/search/rfc4515#section-3}
+ *
+ * @private
+ * @param {string} input - String to sanitize
+ * @returns {string} Sanitized string
+ */
+var sanitizeInput = function(input) {
+  return input
+    .replace(/\*/g, '\\2a')
+    .replace(/\(/g, '\\28')
+    .replace(/\)/g, '\\29')
+    .replace(/\\/g, '\\5c')
+    .replace(/\0/g, '\\00')
+    .replace(/\//g, '\\2f');
+};
+
+/**
  * Create an LDAP auth class. Primary usage is the `.authenticate` method.
  *
  * @param {Object} opts - Config options
@@ -139,8 +158,8 @@ function LdapAuth(opts) {
       var groupSearchFilter = opts.groupSearchFilter;
       opts.groupSearchFilter = function(user) {
         return groupSearchFilter
-          .replace(/{{dn}}/g, user[opts.groupDnProperty])
-          .replace(/{{username}}/g, user.uid);
+          .replace(/{{dn}}/g, sanitizeInput(user[opts.groupDnProperty] || ''))
+          .replace(/{{username}}/g, sanitizeInput(user.uid || ''));
       };
     }
 
@@ -282,25 +301,6 @@ LdapAuth.prototype._search = function(searchBase, options, callback) {
       });
     });
   });
-};
-
-/**
- * Sanitize LDAP special characters from input
- *
- * {@link https://tools.ietf.org/search/rfc4515#section-3}
- *
- * @private
- * @param {string} input - String to sanitize
- * @returns {string} Sanitized string
- */
-var sanitizeInput = function(input) {
-  return input
-    .replace(/\*/g, '\\2a')
-    .replace(/\(/g, '\\28')
-    .replace(/\)/g, '\\29')
-    .replace(/\\/g, '\\5c')
-    .replace(/\0/g, '\\00')
-    .replace(/\//g, '\\2f');
 };
 
 /**


### PR DESCRIPTION
I get errors when the `groupDnProperty` value contains parentheses. I fix it locally with sanitizer.

Explain changes:
- I move `sanitizeInput` to the top of the file cause there was a linter error: `  142:31  error  'sanitizeInput' was used before it was defined  no-use-before-define`
- I use `|| ''` expression to avoid undefined values and error in `sanitizeInput`