### PR TITLE
Make sure groupDnProperty is requested from LDAP server

### DIFF
--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -324,6 +324,12 @@ LdapAuth.prototype._findUser = function(username, callback) {
     opts.attributes = self.opts.searchAttributes;
   }
 
+  // groupDnProperty will be accessed in the user returned by the search, and
+  // so needs to be requested from the LDAP server.
+  if (self.opts.groupDnProperty && !opts.attributes.includes(self.opts.groupDnProperty)) {
+    opts.attributes.push(self.optss.groupDnProperty)
+  }
+
   self._search(self.opts.searchBase, opts, function(err, result) {
     if (err) {
       self.log && self.log.trace('ldap authenticate: user search error: %s %s %s', err.code, err.name, err.message);


### PR DESCRIPTION
`groupDnProperty` is accessed in the user returned by the user search when constructing the group search string, and so needs to be requested from the LDAP server.