### PR TITLE
Added option to handle search timeLimit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Optional ldapjs options, see [ldapjs documentation](https://github.com/mcavage/n
 - `queueSize`
 - `queueTimeout`
 - `queueDisable`
+- `timeLimit`
 
 ## How it works
 

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -104,6 +104,7 @@ function LdapAuth(opts) {
     socketPath: opts.socketPath,
     log: opts.log,
     timeout: opts.timeout,
+    timeLimit: opts.timeLimit,
     connectTimeout: opts.connectTimeout,
     idleTimeout: opts.idleTimeout,
     reconnect: opts.reconnect,

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -316,6 +316,11 @@ LdapAuth.prototype._findUser = function (username, callback) {
 
   var searchFilter = self.opts.searchFilter.replace(/{{username}}/g, sanitizeInput(username));
   var opts = { filter: searchFilter, scope: self.opts.searchScope };
+
+  if (self.opts.timeLimit){
+    opts.timeLimit = self.opts.timeLimit;
+  }
+
   if (self.opts.searchAttributes) {
     opts.attributes = self.opts.searchAttributes;
   }
@@ -372,6 +377,11 @@ LdapAuth.prototype._findGroups = function (user, callback) {
   var searchFilter = self.opts.groupSearchFilter(user);
 
   var opts = { filter: searchFilter, scope: self.opts.groupSearchScope };
+
+  if (self.opts.timeLimit){
+    opts.timeLimit = self.opts.timeLimit;
+  }
+
   if (self.opts.groupSearchAttributes) {
     opts.attributes = self.opts.groupSearchAttributes;
   }


### PR DESCRIPTION
When the ldap search request sent from the client to server the Error pops up like `Time Limit Exceeded` in the response. When I researched the ldapjs has an option `timeLimit` with default is 10 seconds.