### PR TITLE
upgrade ldapjs to 3.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ ldapauth-fork can look for valid users groups too. Related options:
 
 Other ldapauth-fork options:
 
-- `includeRaw` - Optional, default false. Set to true to add property `_raw` containing the original buffers to the returned user object. Useful when you need to handle binary attributes
 - `cache` - Optional, default false. If true, then up to 100 credentials at a time will be cached for 5 minutes.
 - `log` - Bunyan logger instance, optional. If given this will result in TRACE-level error logging for component:ldapauth. The logger is also passed forward to ldapjs.
 

--- a/lib/ldapauth.d.ts
+++ b/lib/ldapauth.d.ts
@@ -92,13 +92,6 @@ declare namespace LdapAuth {
     groupDnProperty?: string;
 
     /**
-     * Set to true to add property '_raw' containing the original buffers
-     * to the returned user object. Useful when you need to handle binary
-     * attributes
-     */
-    includeRaw?: boolean;
-
-    /**
      * If true, then up to 100 credentials at a time will be cached for
      * 5 minutes.
      */

--- a/lib/ldapauth.js
+++ b/lib/ldapauth.js
@@ -279,10 +279,13 @@ LdapAuth.prototype._search = function (searchBase, options, callback) {
 
       var items = [];
       searchResult.on('searchEntry', function (entry) {
-        items.push(entry.object);
-        if (self.opts.includeRaw === true) {
-          items[items.length - 1]._raw = entry.raw;
-        }
+        var pojo = entry.pojo;
+        var entries = pojo.attributes.map(function (att) {
+          return [att.type, att.values.length === 1 ? att.values[0] : att.values];
+        });
+        var object = Object.fromEntries(entries);
+        object.dn = pojo.objectName;
+        items.push(object);
       });
 
       searchResult.on('error', callback);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.5",
       "license": "MIT",
       "dependencies": {
-        "@types/ldapjs": "^2.2.2",
         "bcryptjs": "^2.4.0",
-        "ldapjs": "^2.2.1",
+        "ldapjs": "^3.0.4",
         "lru-cache": "^7.10.1"
       },
       "devDependencies": {
         "@types/bunyan": "^1.8.6",
+        "@types/ldapjs": "^3.0.0",
         "@types/node": "^14.14.7",
         "bunyan": "^1.8.14",
         "eslint": "^8.5.0",
@@ -67,6 +67,83 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ldapjs/asn1": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-2.0.0.tgz",
+      "integrity": "sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA=="
+    },
+    "node_modules/@ldapjs/attribute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/attribute/-/attribute-1.0.0.tgz",
+      "integrity": "sha512-ptMl2d/5xJ0q+RgmnqOi3Zgwk/TMJYG7dYMC0Keko+yZU6n+oFM59MjQOUht5pxJeS4FWrImhu/LebX24vJNRQ==",
+      "dependencies": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "node_modules/@ldapjs/change": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/change/-/change-1.0.0.tgz",
+      "integrity": "sha512-EOQNFH1RIku3M1s0OAJOzGfAohuFYXFY4s73wOhRm4KFGhmQQ7MChOh2YtYu9Kwgvuq1B0xKciXVzHCGkB5V+Q==",
+      "dependencies": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0"
+      }
+    },
+    "node_modules/@ldapjs/controls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/controls/-/controls-2.0.0.tgz",
+      "integrity": "sha512-NpFmdIc2q83tYRGR2a3NDulKgU1e4YOgqjQmmMezCoN4Xz0tju4yB4eibQNC+Zg8YRW06KPwFPKbebDaCqFF0w==",
+      "dependencies": {
+        "@ldapjs/asn1": "^1.2.0",
+        "@ldapjs/protocol": "^1.2.1"
+      }
+    },
+    "node_modules/@ldapjs/controls/node_modules/@ldapjs/asn1": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-1.2.0.tgz",
+      "integrity": "sha512-KX/qQJ2xxzvO2/WOvr1UdQ+8P5dVvuOLk/C9b1bIkXxZss8BaR28njXdPgFCpj5aHaf1t8PmuVnea+N9YG9YMw=="
+    },
+    "node_modules/@ldapjs/dn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/dn/-/dn-1.1.0.tgz",
+      "integrity": "sha512-R72zH5ZeBj/Fujf/yBu78YzpJjJXG46YHFo5E4W1EqfNpo1UsVPqdLrRMXeKIsJT3x9dJVIfR6OpzgINlKpi0A==",
+      "dependencies": {
+        "@ldapjs/asn1": "2.0.0",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "node_modules/@ldapjs/filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/filter/-/filter-2.1.0.tgz",
+      "integrity": "sha512-thjXb98T66r3MdnXIfTba8FdA7wdve+wyn3n9IHaJMm6laaSvcdqI0nvtKeZBaizmWl8V4BQChqHs+csjLHygA==",
+      "dependencies": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "node_modules/@ldapjs/messages": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/messages/-/messages-1.2.0.tgz",
+      "integrity": "sha512-iFYexj32Fwl/duh/egjoFbUbHokJOdnSdviG+V5keiq5BKRL54OKXQTMUPGSHF20MokaaU3m0QAD14Y3b29gIQ==",
+      "dependencies": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0",
+        "@ldapjs/change": "1.0.0",
+        "@ldapjs/controls": "2.0.0",
+        "@ldapjs/dn": "^1.1.0",
+        "@ldapjs/filter": "^2.1.0",
+        "@ldapjs/protocol": "1.2.1",
+        "process-warning": "^2.2.0"
+      }
+    },
+    "node_modules/@ldapjs/protocol": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ldapjs/protocol/-/protocol-1.2.1.tgz",
+      "integrity": "sha512-O89xFDLW2gBoZWNXuXpBSM32/KealKCTb3JGtJdtUQc7RjAk8XzrRgyz02cPAwGKwKPxy0ivuC7UP9bmN87egQ=="
+    },
     "node_modules/@types/bunyan": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.8.tgz",
@@ -77,9 +154,10 @@
       }
     },
     "node_modules/@types/ldapjs": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.2.tgz",
-      "integrity": "sha512-U5HdnwIZ5uZa+f3usxdqgyfNmOROxOxXvQdQtsu6sKo8fte5vej9br2csHxPvXreAbAO1bs8/rdEzvCLpi67nQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-3.0.0.tgz",
+      "integrity": "sha512-Q3QpM+2kqcFFcl7HCF/DC1w/Yg1dlUygft3bAFilrlsOzUTdE3BcN2ZSxa+YcbHAIbxgV7zX0gOTlsXH0mn08Q==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -87,7 +165,8 @@
     "node_modules/@types/node": {
       "version": "14.18.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
-      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q=="
+      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==",
+      "dev": true
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -160,14 +239,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -748,33 +819,25 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/ldap-filter": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
-      "integrity": "sha512-/tFkx5WIn4HuO+6w9lsfxq4FN3O+fDZeO9Mek8dCD8rTUpqzRa766BOBO7BcGkn3X86m5+cBm1/2S/Shzz7gMg==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ldapjs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.3.tgz",
-      "integrity": "sha512-75QiiLJV/PQqtpH+HGls44dXweviFwQ6SiIK27EqzKQ5jU/7UFrl2E5nLdQ3IYRBzJ/AVFJI66u0MZ0uofKYwg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-3.0.4.tgz",
+      "integrity": "sha512-12EIBn7ZfuAVn+ucqsBlSEoxJLsBOyWWqF9Znk3s9LxBvNzy5w/POQxrAK83WND6Mehm+SFiWvKrnH+f4LJ52g==",
       "dependencies": {
-        "abstract-logging": "^2.0.0",
-        "asn1": "^0.2.4",
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0",
+        "@ldapjs/change": "1.0.0",
+        "@ldapjs/controls": "2.0.0",
+        "@ldapjs/dn": "1.1.0",
+        "@ldapjs/filter": "2.1.0",
+        "@ldapjs/messages": "^1.2.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "abstract-logging": "^2.0.1",
         "assert-plus": "^1.0.0",
         "backoff": "^2.5.0",
-        "ldap-filter": "^0.3.3",
         "once": "^1.4.0",
-        "vasync": "^2.2.0",
-        "verror": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
+        "vasync": "^2.2.1",
+        "verror": "^1.10.1"
       }
     },
     "node_modules/levn": {
@@ -1012,6 +1075,11 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1063,11 +1131,6 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1302,6 +1365,85 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ldapjs/asn1": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-2.0.0.tgz",
+      "integrity": "sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA=="
+    },
+    "@ldapjs/attribute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/attribute/-/attribute-1.0.0.tgz",
+      "integrity": "sha512-ptMl2d/5xJ0q+RgmnqOi3Zgwk/TMJYG7dYMC0Keko+yZU6n+oFM59MjQOUht5pxJeS4FWrImhu/LebX24vJNRQ==",
+      "requires": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "@ldapjs/change": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/change/-/change-1.0.0.tgz",
+      "integrity": "sha512-EOQNFH1RIku3M1s0OAJOzGfAohuFYXFY4s73wOhRm4KFGhmQQ7MChOh2YtYu9Kwgvuq1B0xKciXVzHCGkB5V+Q==",
+      "requires": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0"
+      }
+    },
+    "@ldapjs/controls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/controls/-/controls-2.0.0.tgz",
+      "integrity": "sha512-NpFmdIc2q83tYRGR2a3NDulKgU1e4YOgqjQmmMezCoN4Xz0tju4yB4eibQNC+Zg8YRW06KPwFPKbebDaCqFF0w==",
+      "requires": {
+        "@ldapjs/asn1": "^1.2.0",
+        "@ldapjs/protocol": "^1.2.1"
+      },
+      "dependencies": {
+        "@ldapjs/asn1": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-1.2.0.tgz",
+          "integrity": "sha512-KX/qQJ2xxzvO2/WOvr1UdQ+8P5dVvuOLk/C9b1bIkXxZss8BaR28njXdPgFCpj5aHaf1t8PmuVnea+N9YG9YMw=="
+        }
+      }
+    },
+    "@ldapjs/dn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/dn/-/dn-1.1.0.tgz",
+      "integrity": "sha512-R72zH5ZeBj/Fujf/yBu78YzpJjJXG46YHFo5E4W1EqfNpo1UsVPqdLrRMXeKIsJT3x9dJVIfR6OpzgINlKpi0A==",
+      "requires": {
+        "@ldapjs/asn1": "2.0.0",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "@ldapjs/filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/filter/-/filter-2.1.0.tgz",
+      "integrity": "sha512-thjXb98T66r3MdnXIfTba8FdA7wdve+wyn3n9IHaJMm6laaSvcdqI0nvtKeZBaizmWl8V4BQChqHs+csjLHygA==",
+      "requires": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "process-warning": "^2.1.0"
+      }
+    },
+    "@ldapjs/messages": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ldapjs/messages/-/messages-1.2.0.tgz",
+      "integrity": "sha512-iFYexj32Fwl/duh/egjoFbUbHokJOdnSdviG+V5keiq5BKRL54OKXQTMUPGSHF20MokaaU3m0QAD14Y3b29gIQ==",
+      "requires": {
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0",
+        "@ldapjs/change": "1.0.0",
+        "@ldapjs/controls": "2.0.0",
+        "@ldapjs/dn": "^1.1.0",
+        "@ldapjs/filter": "^2.1.0",
+        "@ldapjs/protocol": "1.2.1",
+        "process-warning": "^2.2.0"
+      }
+    },
+    "@ldapjs/protocol": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ldapjs/protocol/-/protocol-1.2.1.tgz",
+      "integrity": "sha512-O89xFDLW2gBoZWNXuXpBSM32/KealKCTb3JGtJdtUQc7RjAk8XzrRgyz02cPAwGKwKPxy0ivuC7UP9bmN87egQ=="
+    },
     "@types/bunyan": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.8.tgz",
@@ -1312,9 +1454,10 @@
       }
     },
     "@types/ldapjs": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.2.tgz",
-      "integrity": "sha512-U5HdnwIZ5uZa+f3usxdqgyfNmOROxOxXvQdQtsu6sKo8fte5vej9br2csHxPvXreAbAO1bs8/rdEzvCLpi67nQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-3.0.0.tgz",
+      "integrity": "sha512-Q3QpM+2kqcFFcl7HCF/DC1w/Yg1dlUygft3bAFilrlsOzUTdE3BcN2ZSxa+YcbHAIbxgV7zX0gOTlsXH0mn08Q==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1322,7 +1465,8 @@
     "@types/node": {
       "version": "14.18.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
-      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q=="
+      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==",
+      "dev": true
     },
     "abstract-logging": {
       "version": "2.0.1",
@@ -1374,14 +1518,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -1826,27 +1962,25 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "ldap-filter": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
-      "integrity": "sha512-/tFkx5WIn4HuO+6w9lsfxq4FN3O+fDZeO9Mek8dCD8rTUpqzRa766BOBO7BcGkn3X86m5+cBm1/2S/Shzz7gMg==",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "ldapjs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.3.tgz",
-      "integrity": "sha512-75QiiLJV/PQqtpH+HGls44dXweviFwQ6SiIK27EqzKQ5jU/7UFrl2E5nLdQ3IYRBzJ/AVFJI66u0MZ0uofKYwg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-3.0.4.tgz",
+      "integrity": "sha512-12EIBn7ZfuAVn+ucqsBlSEoxJLsBOyWWqF9Znk3s9LxBvNzy5w/POQxrAK83WND6Mehm+SFiWvKrnH+f4LJ52g==",
       "requires": {
-        "abstract-logging": "^2.0.0",
-        "asn1": "^0.2.4",
+        "@ldapjs/asn1": "2.0.0",
+        "@ldapjs/attribute": "1.0.0",
+        "@ldapjs/change": "1.0.0",
+        "@ldapjs/controls": "2.0.0",
+        "@ldapjs/dn": "1.1.0",
+        "@ldapjs/filter": "2.1.0",
+        "@ldapjs/messages": "^1.2.0",
+        "@ldapjs/protocol": "^1.2.1",
+        "abstract-logging": "^2.0.1",
         "assert-plus": "^1.0.0",
         "backoff": "^2.5.0",
-        "ldap-filter": "^0.3.3",
         "once": "^1.4.0",
-        "vasync": "^2.2.0",
-        "verror": "^1.8.1"
+        "vasync": "^2.2.1",
+        "verror": "^1.10.1"
       }
     },
     "levn": {
@@ -2032,6 +2166,11 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
+    "process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2065,11 +2204,6 @@
       "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
       "dev": true,
       "optional": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "test": "cd test && node test.js"
   },
   "dependencies": {
-    "@types/ldapjs": "^2.2.2",
     "bcryptjs": "^2.4.0",
-    "ldapjs": "^2.2.1",
+    "ldapjs": "^3.0.4",
     "lru-cache": "^7.10.1"
   },
   "devDependencies": {
+    "@types/ldapjs": "^3.0.0",
     "@types/bunyan": "^1.8.6",
     "@types/node": "^14.14.7",
     "bunyan": "^1.8.14",

--- a/test/test.ts
+++ b/test/test.ts
@@ -19,7 +19,6 @@ const opts: LdapAuth.Options = {
   searchFilter: '(uid={{username}})',
   log: log,
   cache: true,
-  includeRaw: true,
   groupSearchFilter: '(member={{dn}})',
   groupSearchBase: 'dc=example,dc=com',
 };


### PR DESCRIPTION
This is an initial effort to upgrade the `ldapjs` dependency to version 3.

Version 3 breaks this package, so some changes are necessary (see [ldapjs release notes](https://github.com/ldapjs/node-ldapjs/releases/tag/v3.0.0)).

I've tested these changes with a fairly simple setup incl. groups. More comprehensive tests by someone with a slightly more complex use case are probably a good idea.

I have removed the `includeRaw` feature, as `ldapjs` no longer supports it. Binary attributes are handled differently now.

Feel free to build upon or take only parts of this PR if you are only happy with some parts of it.